### PR TITLE
Fix replace of newlines in json.

### DIFF
--- a/app/util/BookStorage.ts
+++ b/app/util/BookStorage.ts
@@ -47,7 +47,7 @@ async function addBookToList(filename: string, list: Book[]): Promise<Book> {
   const book = {
     filename: filename,
     title: metaData.title,
-    allTitles: JSON.parse(metaData.allTitles.replace("\n", " ")), // Remove newlines to avoid JSON parse error
+    allTitles: JSON.parse(metaData.allTitles.replace(/\n/g, " ")), // Remove newlines to avoid JSON parse error
     tags: metaData.tags,
     thumbPath: thumbPath,
     modifiedAt: Date.now()


### PR DESCRIPTION
From the docs:

> If pattern is a string, only the first occurrence will be replaced.

We want all matches to be replaced.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomreader-rn/16)
<!-- Reviewable:end -->
