### PR TITLE
Fix copyAssets task

### DIFF
--- a/copyWebModules.js
+++ b/copyWebModules.js
@@ -1,0 +1,14 @@
+const fs = require("fs");
+
+const bloomPlayerAssetFolderPath = "./android/app/src/main/assets/bloom-player";
+
+mkdirSafe(bloomPlayerAssetFolderPath);
+
+fs.copyFileSync(
+  "./node_modules/bloom-player-react/output/bloomPlayerControlBundle.js",
+  `${bloomPlayerAssetFolderPath}/bloomPlayerControlBundle.js`
+);
+
+function mkdirSafe(path) {
+  if (!fs.existsSync(path)) fs.mkdirSync(path);
+}

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "2.0.0",
   "private": true,
   "scripts": {
-    "copyAssets": "node -e \"fs.copyFileSync('./node_modules/bloom-player-react/output/bloomPlayerControlBundle.js','./android/app/src/main/assets/bloom-player/bloomPlayerControlBundle.js')\"",
-    "start-android": "npm run copyAssets && react-native run-android",
+    "copyWebModules": "node ./copyWebModules.js",
+    "start-android": "npm run copyWebModules && react-native run-android",
     "start": "node node_modules/react-native/local-cli/cli.js start",
     "test": "jest --testPathPattern app",
     "test-watch": "jest --watch --testPathPattern app",


### PR DESCRIPTION
The original task fails if there is not already bloom-player folder in the android assets. Now it makes that folder if necessary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomreader-rn/20)
<!-- Reviewable:end -->
