### PR TITLE
Remove SYSTEM ALERT WINDOW permission from release builds.

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
     <!-- Used by RN for debugging -->
     <uses-permission android:name="android.permission.INTERNET" />
 
-    <!-- Used by RN for debugging - need to remove from production-->
+    <!-- Used by RN for debugging - removed in release builds by android/app/release/AndroidManifest.xml -->
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
 
     <!-- Get name of Wifi network for receiving books -->

--- a/android/app/src/release/AndroidManifest.xml
+++ b/android/app/src/release/AndroidManifest.xml
@@ -1,0 +1,7 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="org.sil.bloom.reader"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <uses-permission tools:node="remove" android:name="android.permission.SYSTEM_ALERT_WINDOW" />
+
+</manifest>


### PR DESCRIPTION
Issue: https://issues.bloomlibrary.org/youtrack/issue/BL-7138

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomreader-rn/25)
<!-- Reviewable:end -->
