### PR TITLE
Upgrade JQuery due to vulnerability: CVE-2019-11358

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "int-test": "jest --testPathPattern integration-tests"
   },
   "dependencies": {
-    "bloom-player": "^0.6.1",
     "@segment/analytics-react-native": "^0.0.1-beta.5",
+    "bloom-player": "^0.6.1",
     "react": "16.6.3",
     "react-native": "0.57.8",
     "react-native-email": "^1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4831,9 +4831,9 @@ jpeg-js@^0.3.4:
   integrity sha512-6IzjQxvnlT8UlklNmDXIJMWxijULjqGrzgqc0OG7YadZdvm7KPQ1j0ehmQQHckgEWOfgpptzcnWgESovxudpTA==
 
 jquery@^3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.3.1.tgz#958ce29e81c9790f31be7792df5d4d95fc57fbca"
-  integrity sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg==
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
+  integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
CVE-2019-11358

moderate severity
Vulnerable versions: < 3.4.0
Patched version: 3.4.0
jQuery before 3.4.0, as used in Drupal, Backdrop CMS, and other products, mishandles jQuery.extend(true, {}, ...) because of Object.prototype pollution. If an unsanitized source object contained an enumerable proto property, it could extend the native Object.prototype.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomreader-rn/36)
<!-- Reviewable:end -->
