### PR TITLE
[BL-7141] Improve bloombundle import with Bug Fixes

### DIFF
--- a/Design Decisions.md
+++ b/Design Decisions.md
@@ -25,18 +25,3 @@ In the previous BloomReader, books within a certain folder on the SD Card are in
 
 If the user opens a .bloomd with the same name as a book in the library, the new file replaces the old one and the list entry is updated. This prevents ending up with multiple copies of a book accidentally, but it does mean that you can't have two books with the exact same title.
 
-
-## Import
-
-### BloomBundle Import
-
-In the previous BloomReader, we were dealing with a bug in unpacking BloomBundles* where the FileDescriptor would mysteriously go bad at random intervals. Our workaround was to keep trying until the unpacking was successful. 
-
-I tried to avoid that pain by brining in an unarchiving library, but it depends on having the archive as a File object, and Android gives us a URI. So what the code does right now is copy the bundle from the URI to our own storage, unpack the bundle there, and delete the bundle. The downside is that during the unpack process, this is bundle is potentially consuming 3 times its own size worth of on-device storage - one copy wherever it came from originally, one archived copy in our storage and one unpacked copy in our storage. (That's assuming the original source of the file is on-device storage). A lot of our users have limited on-device storage and this may present an issue for them. 
-
-Other options would be to 
-
-1. Hold our nose and use the unpack function from the previous BR
-2. Research a third method
-
-*Bloombundles are simply tar archives with bloom book and shelf files inside.

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -211,7 +211,7 @@ dependencies {
     implementation project(':react-native-gesture-handler')
     implementation project(':react-native-fs')
 
-    implementation 'org.rauschig:jarchivelib:0.7.1'
+    implementation  'org.apache.commons:commons-compress:1.18'
     // Supports the WiFi module's 'server' used to receive books from Bloom desktop
     implementation  'cz.msebera.android:httpclient:4.4.1.2'
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -24,12 +24,6 @@
         android:allowBackup="false"
         android:theme="@style/AppTheme">
         <activity
-            android:name=".MainActivity"
-            android:label="@string/app_name"
-            android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
-            android:windowSoftInputMode="adjustResize">
-        </activity>
-        <activity
             android:name=".SplashActivity"
             android:label="@string/app_name"
             android:theme="@style/SplashTheme">
@@ -37,7 +31,12 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
-
+        </activity>
+        <activity
+            android:name=".MainActivity"
+            android:label="@string/app_name"
+            android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
+            android:windowSoftInputMode="adjustResize">
 
             <!--
                 In reworking these filters for BL-6941, this answer seemed the clearest to follow:

--- a/android/app/src/main/java/org/sil/bloom/reader/IOUtilities.java
+++ b/android/app/src/main/java/org/sil/bloom/reader/IOUtilities.java
@@ -1,48 +1,15 @@
 package org.sil.bloom.reader;
 
-//import android.content.Context;
-//import android.content.res.AssetManager;
-//import android.net.Uri;
-//import android.os.Build;
-//import android.os.Environment;
-//import android.util.Log;
-//import android.widget.Toast;
-//
-//import org.apache.commons.compress.archivers.ArchiveEntry;
-//import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
-//import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
-//import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
-//import org.apache.commons.io.IOUtils;
-//import org.sil.bloom.reader.models.BookCollection;
-//import org.sil.bloom.reader.models.BookOrShelf;
-//import org.sil.bloom.reader.models.ExtStorageUnavailableException;
-//
-//import java.io.BufferedInputStream;
-//import java.io.File;
-//import java.io.FileDescriptor;
-//import java.io.FileInputStream;
-//import java.io.FileNotFoundException;
-//import java.io.FileOutputStream;
-//import java.io.FileWriter;
-//import java.io.FilenameFilter;
-//import java.io.IOException;
-//import java.io.InputStream;
-//import java.io.OutputStream;
-//import java.nio.charset.StandardCharsets;
-//import java.text.SimpleDateFormat;
-//import java.util.Date;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
-import java.util.zip.ZipInputStream;
-import java.util.zip.ZipOutputStream;
-//
-//import static org.sil.bloom.reader.models.BookCollection.getLocalBooksDirectory;
 
 
 import android.content.Context;
 import android.net.Uri;
 
+import org.apache.commons.compress.archivers.ArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import org.apache.commons.compress.utils.IOUtils;
 
@@ -322,31 +289,31 @@ public class IOUtilities {
 //        //zip(getLocalBooksDirectory().getAbsolutePath(), filter, destinationPath);
 //    }
 //
-//    public static String extractTarEntry(TarArchiveInputStream tarInput, String targetPath) throws IOException {
-//        ArchiveEntry entry = tarInput.getCurrentEntry();
-//        File destPath=new File(targetPath,entry.getName());
-//        if (!entry.isDirectory()) {
-//            FileOutputStream fout=new FileOutputStream(destPath);
-//            try{
-//                final byte[] buffer=new byte[8192];
-//                int n=0;
-//                while (-1 != (n=tarInput.read(buffer))) {
-//                    fout.write(buffer,0,n);
-//                }
-//                fout.close();
-//            }
-//            catch (IOException e) {
-//                fout.close();
-//                destPath.delete();
-//                tarInput.close();
-//                throw e;
-//            }
-//        }
-//        else {
-//            destPath.mkdir();
-//        }
-//        return destPath.getPath();
-//    }
+    public static String extractTarEntry(TarArchiveInputStream tarInput, String targetPath) throws IOException {
+        ArchiveEntry entry = tarInput.getCurrentEntry();
+        File destPath=new File(targetPath,entry.getName());
+        if (!entry.isDirectory()) {
+            FileOutputStream fout=new FileOutputStream(destPath);
+            try{
+                final byte[] buffer=new byte[8192];
+                int n=0;
+                while (-1 != (n=tarInput.read(buffer))) {
+                    fout.write(buffer,0,n);
+                }
+                fout.close();
+            }
+            catch (IOException e) {
+                fout.close();
+                destPath.delete();
+                tarInput.close();
+                throw e;
+            }
+        }
+        else {
+            destPath.mkdir();
+        }
+        return destPath.getPath();
+    }
 //
 //    public static File nonRemovablePublicStorageRoot(Context context) {
 //        return publicStorageRoot(context, false);
@@ -400,5 +367,23 @@ public class IOUtilities {
                 path.lastIndexOf(':'))
                 + 1;
         return path.substring(start);
+    }
+
+    public static void extractBloomBundle(Context context, Uri bloomBundleUri, String targetDirectoryPath) throws IOException {
+        TarArchiveInputStream tarInput = null;
+        try {
+            InputStream fs = context.getContentResolver().openInputStream(bloomBundleUri);
+            tarInput = new TarArchiveInputStream(fs);
+            ArchiveEntry entry = null;
+            while ((entry = tarInput.getNextEntry()) != null) {
+                extractTarEntry(tarInput, targetDirectoryPath);
+            }
+            tarInput.close();
+            return;
+        } catch (IOException e) {
+            if (tarInput != null)
+                tarInput.close();
+            throw e;
+        }
     }
 }

--- a/android/app/src/main/java/org/sil/bloom/reader/ImportBookModule.java
+++ b/android/app/src/main/java/org/sil/bloom/reader/ImportBookModule.java
@@ -12,11 +12,7 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
-import com.facebook.react.modules.core.DeviceEventManagerModule;
 
-import org.rauschig.jarchivelib.ArchiveFormat;
-import org.rauschig.jarchivelib.Archiver;
-import org.rauschig.jarchivelib.ArchiverFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -103,16 +99,10 @@ public class ImportBookModule extends ReactContextBaseJavaModule {
     }
 
     private String importBloomBundle(Uri uri, String filename) throws IOException {
-        String bundlePath = context.getCacheDir() + File.separator + filename;
-        Log.d("ImportBook", "Copying " + filename + " to " + bundlePath);
-        IOUtilities.copyFile(context, uri, bundlePath);
-
-        Log.d("ImportBook", "Extracting " + filename);
-        File bundle = new File(bundlePath);
-        File extractDirectory = new File(bundlePath + "_files");
-        Archiver archiver = ArchiverFactory.createArchiver(ArchiveFormat.TAR);
-        archiver.extract(bundle, extractDirectory);
-        bundle.delete();
-        return extractDirectory.getPath();
+        String extractPath = context.getCacheDir() + File.separator + filename + "_FILES";
+        Log.d("ImportBook", "Extracting " + filename + " to " + extractPath);
+        new File(extractPath).mkdir();
+        IOUtilities.extractBloomBundle(context, uri, extractPath);
+        return extractPath;
     }
 }

--- a/app/models/BookOrShelf.test.ts
+++ b/app/models/BookOrShelf.test.ts
@@ -2,8 +2,8 @@ import {
   displayName,
   isShelf,
   goesOnShelf,
-  listForShelf,
-  recursiveListForShelf
+  recursiveListForShelf,
+  sortedListForShelf
 } from "./BookOrShelf";
 import I18n from "../i18n/i18n";
 import { bookFactory, shelfFactory } from "../test/testHelper";
@@ -102,31 +102,32 @@ const bookCollection = {
   books: [...twoRootBooks, ...twoShelf1Books, ...twoChildShelfBooks],
   shelves: [...threeShelves(), childShelfofShelf1]
 };
-test("listForShelf lists books and shelves on that shelf", () => {
+test("sortedListForShelf lists books and shelves on that shelf", () => {
   const theThreeShelves = threeShelves();
-  expect(listForShelf(theThreeShelves[0], bookCollection)).toEqual([
-    childShelfofShelf1,
-    ...twoShelf1Books
+  expect(sortedListForShelf(theThreeShelves[0], bookCollection)).toEqual([
+    ...twoShelf1Books,
+    childShelfofShelf1
   ]);
-  expect(listForShelf(childShelfofShelf1, bookCollection)).toEqual(
+  expect(sortedListForShelf(childShelfofShelf1, bookCollection)).toEqual(
     twoChildShelfBooks
   );
-  expect(listForShelf(theThreeShelves[2], bookCollection)).toEqual([]);
+  expect(sortedListForShelf(theThreeShelves[2], bookCollection)).toEqual([]);
 });
 
 test("listForShelf lists root books and shelves for undefined", () => {
   const theThreeShelves = threeShelves();
-  expect(listForShelf(undefined, bookCollection)).toEqual([
-    ...theThreeShelves,
-    ...twoRootBooks
+  expect(sortedListForShelf(undefined, bookCollection)).toEqual([
+    ...twoRootBooks,
+    ...theThreeShelves
   ]);
 });
 
 test("completeListForShelf includes subshelf contents", () => {
   const theThreeShelves = threeShelves();
   expect(recursiveListForShelf(theThreeShelves[0], bookCollection)).toEqual([
-    childShelfofShelf1,
+    theThreeShelves[0],
     ...twoShelf1Books,
+    childShelfofShelf1,
     ...twoChildShelfBooks
   ]);
 });

--- a/app/native_modules/ImportBookModule.ts
+++ b/app/native_modules/ImportBookModule.ts
@@ -1,6 +1,5 @@
 import { NativeModules } from "react-native";
 import RNFS from "react-native-fs";
-import * as FileUtil from "../util/FileUtil";
 import {
   BookCollectionWithNewBook,
   importBookDirToCollection,
@@ -18,10 +17,7 @@ export async function checkForBooksToImport(): Promise<
     if (statResult.isDirectory())
       return await importBookDirToCollection(importPath);
     else {
-      return await importBookToCollection(
-        FileUtil.nameFromPath(importPath),
-        "FileIntent"
-      );
+      return await importBookToCollection(importPath, "FileIntent");
     }
   }
 }


### PR DESCRIPTION
Issue: https://issues.bloomlibrary.org/youtrack/issue/BL-7141

 - Incorporate improved bundle unpacking from BR 1.3. This version avoids creating an unnecessary copy of the bundle on disk.
 - Fix bug causing book import to crash
 - Fix bug causing collection not to refresh after bundle import
 - Improve shelf bundle export by including the shelf file for the shelf being exported (Resulted in simplified code for delete as well)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomreader-rn/43)
<!-- Reviewable:end -->
