### PR TITLE
Remove nonfunctional 'Find bloom books on this device' from the drawer menu

### DIFF
--- a/app/components/DrawerMenu/DrawerMenu.tsx
+++ b/app/components/DrawerMenu/DrawerMenu.tsx
@@ -51,11 +51,6 @@ export default class DrawerMenu extends React.PureComponent<
             this.props.navigation.closeDrawer();
           }}
         />
-        <DrawerMenuItem
-          label={I18n.t("Find Bloom books on this device")}
-          iconSource={require("../../assets/bookshelf.png")}
-          onPress={() => {}}
-        />
         <View style={{ borderBottomWidth: 1, borderBottomColor: "gray" }} />
         <DrawerMenuItem
           label={I18n.t("Release Notes")}

--- a/app/i18n/locales/fr.json
+++ b/app/i18n/locales/fr.json
@@ -3,7 +3,6 @@
   "Receive books from computer": "Recevoir des livres depuis un ordinateur",
   "Share Books": "Partager des livres",
   "Share Bloom Reader app": "Partager l'application Bloom Reader",
-  "Find Bloom books on this device": "Trouver des livres Bloom sur cet appareil",
   "Release Notes": "Notes de publication",
   "About Bloom Reader": "À propos de Bloom Reader",
   "About Bloom": "À propos de Bloom",


### PR DESCRIPTION
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomreader-rn/46)
<!-- Reviewable:end -->
