### PR TITLE
Minor fixes to copyWebModules task.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,11 +63,6 @@ integration-tests/emulators
 android/app/release
 
 #Copied into source tree by package.json script from node_modules
-*bloomPlayer.js
-*bloomPlayer.js.map
-*bloomPlayer.min.js
-*bloomPlayer.js.min.map
-*right_answer.mp3
-*wrong_answer.mp3
-*simpleComprehensionQuiz.js
+android/app/src/main/assets/bloom-player
+
 *.orig

--- a/android/app/src/main/assets/bloom-player/webView.htm
+++ b/android/app/src/main/assets/bloom-player/webView.htm
@@ -1,9 +1,0 @@
-<!DOCTYPE html>
-<!-- This file becomes the root of the webview used to display books. A urlParam specifies the book.-->
-<html>
-  <head> </head>
-  <body>
-    Failed to run react!
-  </body>
-  <script src="bloomPlayer.min.js"></script>
-</html>

--- a/app/components/BookReader/BookReader.tsx
+++ b/app/components/BookReader/BookReader.tsx
@@ -63,7 +63,7 @@ export default class BookReader extends React.PureComponent<IProps, IState> {
         {this.state.bookReady && (
           <WebView
             source={{
-              uri: `file:///android_asset/bloom-player/webView.htm?url=${bookUrl}`
+              uri: `file:///android_asset/bloom-player/bloomplayer.htm?url=${bookUrl}`
             }}
             mixedContentMode="always"
             allowUniversalAccessFromFileURLs={true}

--- a/copyWebModules.js
+++ b/copyWebModules.js
@@ -1,27 +1,20 @@
 const fs = require("fs");
 
+const nodeModulePath = "./node_modules/bloom-player/dist";
 const bloomPlayerAssetFolderPath = "./android/app/src/main/assets/bloom-player";
+const filesToNotCopy = ["bloomPlayer.js"];
+
+const moduleFiles = fs.readdirSync(nodeModulePath);
+const moduleFilesToCopy = moduleFiles.filter(
+  filename => !filesToNotCopy.includes(filename)
+);
 
 mkdirSafe(bloomPlayerAssetFolderPath);
-
-fs.copyFileSync(
-  "./node_modules/bloom-player/dist/bloomPlayer.js",
-  `${bloomPlayerAssetFolderPath}/bloomPlayer.min.js`
-);
-
-fs.copyFileSync(
-  "./node_modules/bloom-player/dist/right_answer.mp3",
-  `${bloomPlayerAssetFolderPath}/right_answer.mp3`
-);
-
-fs.copyFileSync(
-  "./node_modules/bloom-player/dist/wrong_answer.mp3",
-  `${bloomPlayerAssetFolderPath}/wrong_answer.mp3`
-);
-
-fs.copyFileSync(
-  "./node_modules/bloom-player/dist/simpleComprehensionQuiz.js",
-  `${bloomPlayerAssetFolderPath}/simpleComprehensionQuiz.js`
+moduleFilesToCopy.forEach(filename =>
+  fs.copyFileSync(
+    `${nodeModulePath}/${filename}`,
+    `${bloomPlayerAssetFolderPath}/${filename}`
+  )
 );
 
 function mkdirSafe(path) {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "appium-doctor": "^1.9.0",
     "babel-jest": "^24.8.0",
     "concurrently": "^4.1.0",
-    "fs": "^0.0.1-security",
     "jest": "^24.8.0",
     "jest-teamcity-reporter": "^0.9.0",
     "metro-react-native-babel-preset": "^0.54.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4320,11 +4320,6 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
-fs@^0.0.1-security:
-  version "0.0.1-security"
-  resolved "https://registry.yarnpkg.com/fs/-/fs-0.0.1-security.tgz#8a7bd37186b6dddf3813f23858b57ecaaf5e41d4"
-  integrity sha1-invTcYa23d84E/I4WLV+yq9eQdQ=
-
 fsevents@2.x:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.0.6.tgz#87b19df0bfb4a1a51d7ddb51b01b5f3bedb40c33"


### PR DESCRIPTION
 - Remove `fs` from devDependencies. It shouldn't be there - it's part of `node`.
 - Rewrite `copyWebModules.js` which
    - removes error copying bloomPlayer.min.js into bloomPlayer.js
    - future proofs the task by copying all expect blacklisted files
- Use `bloomplayer.htm` from the module rather than having a separate (but nearly identical) webView.htm file in the BR repo (Which was also the source of the message "Failed to run React!").

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomreader-rn/53)
<!-- Reviewable:end -->
